### PR TITLE
Use theme font and use background to calculate hyperline background

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "scripts": {
     "build": "NODE_ENV=production webpack",
     "dev": "webpack --watch"
+  },
+  "dependencies": {
+    "color": "^0.11.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import Color from 'color'
+
 import { getColorList } from './lib/utils/colors'
 import { hostnameFactory } from "./lib/info-items/hostname"
 import { memoryFactory } from "./lib/info-items/memory"
@@ -9,22 +11,17 @@ const LINE_PADDING = "10px"
 const FONT_STYLE = "bold 12px Monospace"
 const ITEM_MARGIN = "7px"
 
-const LINE_COLOR = "#222222"
-
-const HOSTNAME_COLOR = "#00D0FF"
-const MEMORY_INFO_COLOR = "#FFFFFF"
-const UPTIME_INFO_COLOR = "#FFCC00"
-
 export function mapHyperTermState (state, map) {
   return Object.assign({}, map, {
-    colors: state.ui.colors
+    colors    : state.ui.colors,
+    fontFamily: state.ui.fontFamily
   })
 }
 
 export function decorateHyperTerm (HyperTerm, { React }) {
-  const HyperLine = ({ children }) => {
+  const HyperLine = ({ style, colors, plugins }) => {
     return (
-      <div style={{
+      <div style={Object.assign({}, {
         display      : "flex",
         alignItems   : "center",
         position     : "absolute",
@@ -33,11 +30,18 @@ export function decorateHyperTerm (HyperTerm, { React }) {
         height       : LINE_HEIGHT,
         paddingLeft  : LINE_PADDING,
         paddingRight : LINE_PADDING,
-        background   : LINE_COLOR,
         font         : FONT_STYLE,
         pointerEvents: "none"
-      }}>
-        {children}
+      }, style)}>
+        {
+          plugins.map((item) => {
+            const Component = item.componentFactory(React, colors)
+            return <Component style={{
+              marginRight: ITEM_MARGIN,
+              color      : item.color
+            }} />
+          })
+        }
       </div>
     )
   }
@@ -69,15 +73,14 @@ export function decorateHyperTerm (HyperTerm, { React }) {
 
     render () {
       return <HyperTerm {...this.props} customChildren={(
-        <HyperLine>
-          {this.plugins.map((item) => {
-            const Component = item.componentFactory(React, this.colors)
-            return <Component style={{
-              marginRight: ITEM_MARGIN,
-              color      : item.color
-            }} />
-          })}
-        </HyperLine>
+        <HyperLine
+          style={{
+          fontFamily: this.props.fontFamily,
+          background: Color(this.colors.black).darken(0.2).hslString()
+          }}
+          colors={this.colors}
+          plugins={this.plugins}
+        />
       )} />
     }
   }


### PR DESCRIPTION
Related to #4. I forgot to do the font styling 😉 
The dependency on `color` is needed because a theme may use something like a rgba color.

Looks quite good 👍 
<img width="1201" alt="screen shot 2016-08-15 at 20 51 26" src="https://cloud.githubusercontent.com/assets/6324199/17675438/12552aa8-632a-11e6-834e-42972c099637.png">
