### PR TITLE
Add setup steps for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To set up the project for development:
 
 1. Clone this repository into `~/.hyperterm_plugins/local/`
 2. Run `npm install` within the project directory
-3. Run `npm run build` to build the plugin OR `npm run dev` to build the plugin and watch for file changes.
+3. Run `npm run build` to build the plugin **OR** `npm run dev` to build the plugin and watch for file changes.
 4. Add the name of the directory to `localPlugins` in `~/.hyperterm.js`.
 5. Reload terminal window
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ plugins: [
 
 Feel free to contribute to HyperLine by [requesting a feature](https://github.com/NickTikhonov/hyperterm-hyperline/issues/new), [submitting a bug](https://github.com/NickTikhonov/hyperterm-hyperline/issues/new) or contributing code.
 
-To set up the package for development, clone this repository into `~/.hyperterm_plugins/local/` and add the name of the directory to `localPlugins` in `~/.hyperterm.js`.
+To set up the project for development:
+
+1. Clone this repository into `~/.hyperterm_plugins/local/`
+2. Run `npm install` within the project directory
+3. Run `npm run build` to build the plugin OR `npm run dev` to build the plugin and watch for file changes.
+4. Add the name of the directory to `localPlugins` in `~/.hyperterm.js`.
+5. Reload terminal window
 
 ## License
 


### PR DESCRIPTION
This was brought on #19 and provides clear steps on what to do after the repository has been cloned. 