### PR TITLE
added battery level plugin, Tested on Mac, test needed for Window and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 dist
+DS_Store

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import {hostnameFactory} from './lib/plugins/hostname'
 import {memoryFactory} from './lib/plugins/memory'
 import {uptimeFactory} from './lib/plugins/uptime'
 import {cpuFactory} from './lib/plugins/cpu'
+import {batteryFactory} from './lib/plugins/battery'
 
 export function mapHyperTermState(state, map) {
   return Object.assign({}, map, {
@@ -47,6 +48,10 @@ export function decorateHyperTerm(HyperTerm, {React}) {
         {
           componentFactory: cpuFactory,
           color: 'transparent'
+        },
+        {
+          componentFactory: batteryFactory,
+          color: this.colors.blue
         }
       ]
     }

--- a/src/lib/plugins/battery.js
+++ b/src/lib/plugins/battery.js
@@ -1,0 +1,71 @@
+import child_process from 'child_process'
+
+// global values
+let cmdBattery = '' // system command for battery level
+
+export function batteryFactory(React) {
+  return class extends React.Component {
+    static displayName() {
+      return 'Battery plugin'
+    }
+
+    static propTypes() {
+      return {
+        style: React.PropTypes.object
+      }
+    }
+
+    constructor(props) {
+      super(props)
+
+      this.state = {
+        battery: this.getBattery()
+      }
+
+      // Recheck every 2 minutes
+      setInterval(() => this.getBattery(), 60000 * 2)
+    }
+
+    getBattery() {
+      if (process.platform === 'darwin') {
+        // terminal command for mac os
+        cmdBattery = 'pmset -g batt | egrep "([0-9]+\%).*" -o'
+        child_process.exec(cmdBattery, (error, stdout) => {
+          if (error) {
+            throw error
+          }
+          const batteryArray = stdout.trim().split(';')
+          let batteryLevel = `🔋 ${batteryArray[0]}`
+
+          this.setState({batteryLevel})
+
+          return batteryLevel
+        })
+      } else if (process.platform === 'linux') {
+        // terminal command for linux
+        // cmdBattery = 'add linux command'
+        let batteryLevel = '🔋 😔'
+
+        this.setState({batteryLevel})
+
+        return batteryLevel
+      } else if (process.platform === 'win32') {
+        // terminal command for windows
+        // cmdBattery = 'add windows command'
+        let batteryLevel = '🔋 😔'
+
+        this.setState({batteryLevel})
+
+        return batteryLevel
+      }
+    }
+
+    render() {
+      return (
+        <div style={this.props.style}>
+          {this.state.batteryLevel}
+        </div>
+      )
+    }
+  }
+}

--- a/src/lib/plugins/battery.js
+++ b/src/lib/plugins/battery.js
@@ -1,7 +1,8 @@
 import child_process from 'child_process'
 
-// global values
-let cmdBattery = '' // system command for battery level
+// global system command for battery
+// is defined for each operating system.
+let cmdBattery = ''
 
 export function batteryFactory(React) {
   return class extends React.Component {
@@ -52,6 +53,13 @@ export function batteryFactory(React) {
       } else if (process.platform === 'win32') {
         // terminal command for windows
         // cmdBattery = 'add windows command'
+        let batteryLevel = '🔋 😔'
+
+        this.setState({batteryLevel})
+
+        return batteryLevel
+      } else {
+        // unsupported OS
         let batteryLevel = '🔋 😔'
 
         this.setState({batteryLevel})


### PR DESCRIPTION
I made a battery level plugin 🎉 

It has been tested on mac os. Here is the screenshot. I added the battery icon (🔋)  to separate it from the other values. 
<img width="356" alt="screen shot 2016-08-27 at 20 00 24" src="https://cloud.githubusercontent.com/assets/11923550/18029907/5691ec66-6c9d-11e6-877c-f2170b75848f.png">

I have added dummy code for the other platforms. For windows and linux systems it renders a 😞 
<img width="349" alt="screen shot 2016-08-27 at 21 06 59" src="https://cloud.githubusercontent.com/assets/11923550/18029927/97724816-6c9d-11e6-9f4f-89ddd860e67b.png">

In order to show the battery level in Windows and Linux, we only need to add the system command for those systems in the else..if statements inside.

I don't own Windows or Linux, so can't test them.


