### PR TITLE
Move required modules outside of bundled hyperline.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "one-var": 0
   },
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "color": "^0.11.3",
+    "json-loader": "^0.5.4",
     "webpack-node-externals": "^1.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dev": "webpack --watch"
   },
   "dependencies": {
-    "color": "^0.11.3"
+    "color": "^0.11.3",
+    "webpack-node-externals": "^1.3.3"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,10 @@
+const webpack = require('webpack')
+const nodeExternals = require('webpack-node-externals')
+
 module.exports = {
   entry: './src/index.js',
   target: 'node',
+  externals: [nodeExternals()],
   output: {
     path: './dist',
     filename: 'hyperline.js',
@@ -16,6 +20,10 @@ module.exports = {
     ],
     loaders: [
       {
+        test: /\.json$/,
+        loader: 'json-loader'
+      },
+      {
         test: /\.js$/,
         loader: [
           'babel'
@@ -30,7 +38,10 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    new webpack.DefinePlugin({ 'global.GENTLY': false })
+  ],
   eslint: {
     configFile: '.eslintrc'
   }
-};
+}


### PR DESCRIPTION
Hey Nick,
Atm we're compiling dependencies into the hyperline package javascript. This is unneeded since hyperterm automagically runs npm install when installing the package. Please merge this so I can fix #22 👍 