### PR TITLE
Update systeminformation dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "color": "^0.11.3",
     "json-loader": "^0.5.4",
-    "systeminformation": "^3.4.1",
+    "systeminformation": "^3.4.2",
     "webpack-node-externals": "^1.3.3"
   }
 }


### PR DESCRIPTION
The systeminformation library we are using to get the network traffic speed for the Network plugin had a bug related with a function used to get the active network interface as it is documented in this [issue #12](https://github.com/sebhildebrandt/systeminformation/issues/12).

The team behind the library already published a [fix: 9980bfd](https://github.com/sebhildebrandt/systeminformation/commit/09e4518bb90f5e010fae3cd3cab63b6199980bfd) for this bug. 