### PR TITLE
Prevent network plugin from showing "NaNkB/s"

### DIFF
--- a/src/lib/plugins/network.js
+++ b/src/lib/plugins/network.js
@@ -46,12 +46,12 @@ export function componentFactory(React, colors) {
 
     buildStateObject(data) {
       let rawDownload = data.rx_sec / 1024
-      if (rawDownload < 0) {
+      if (rawDownload < 0 || isNaN(rawDownload)) {
         rawDownload = 0
       }
 
       let rawUpload = data.tx_sec / 1024
-      if (rawUpload < 0) {
+      if (rawUpload < 0 || isNaN(rawUpload)) {
         rawUpload = 0
       }
 


### PR DESCRIPTION
Add a safeguard to not show `NaN` to the end user